### PR TITLE
feat#18-mainpage-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.10)(react@19.1.1)
@@ -486,6 +489,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -497,6 +513,24 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -532,6 +566,32 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2941,6 +3001,18 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       react: 19.1.1
@@ -2949,6 +3021,19 @@ snapshots:
 
   '@radix-ui/react-context@1.1.2(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.10)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.10)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
@@ -2975,6 +3060,41 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,1 @@
+export * from './main';

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -2,8 +2,23 @@ import { useState } from 'react';
 
 import { Button, Input, Label, RadioGroup, RadioGroupItem } from '@/shared';
 
+import {
+  FORM_FIELDS,
+  LABEL_TEXTS,
+  PLACEHOLDER_TEXTS,
+  RENT_TYPES,
+  RENT_TYPE_CONFIG,
+} from '../../../constants';
+import type { RentType } from '../../../types';
+
 export const DiagnosticForm = () => {
-  const [rentType, setRentType] = useState<'jeonse' | 'monthly'>('jeonse');
+  const [rentType, setRentType] = useState<RentType>(RENT_TYPES.JEONSE);
+
+  const handleRentTypeChange = (value: string) => {
+    setRentType(value as RentType);
+  };
+
+  const currentRentConfig = RENT_TYPE_CONFIG[rentType];
 
   //TODO: 추후 Form 컴포넌트로 리팩토링
   return (
@@ -11,50 +26,43 @@ export const DiagnosticForm = () => {
       <div className='flex w-4/5 flex-col gap-2'>
         <div className='flex w-full flex-col gap-4'>
           <div className='flex flex-col gap-2'>
-            <Label htmlFor='address' className='text-sm font-medium'>
-              주소
+            <Label htmlFor={FORM_FIELDS.ADDRESS} className='text-sm font-medium'>
+              {LABEL_TEXTS.ADDRESS}
             </Label>
-            <Input id='address' placeholder='주소를 알려주세요' />
+            <Input id={FORM_FIELDS.ADDRESS} placeholder={PLACEHOLDER_TEXTS.ADDRESS} />
           </div>
           <div className='flex flex-col gap-2'>
-            <Label htmlFor='house-type' className='text-sm font-medium'>
-              주택유형
+            <Label htmlFor={FORM_FIELDS.HOUSE_TYPE} className='text-sm font-medium'>
+              {LABEL_TEXTS.HOUSE_TYPE}
             </Label>
-            <Input id='house-type' placeholder='주택유형을 알려주세요' />
+            <Input id={FORM_FIELDS.HOUSE_TYPE} placeholder={PLACEHOLDER_TEXTS.HOUSE_TYPE} />
           </div>
           <div className='flex flex-col gap-2'>
-            <Label htmlFor='detail-address' className='text-sm font-medium'>
-              상세주소
+            <Label htmlFor={FORM_FIELDS.DETAIL_ADDRESS} className='text-sm font-medium'>
+              {LABEL_TEXTS.DETAIL_ADDRESS}
             </Label>
-            <Input id='detail-address' placeholder='상세주소를 알려주세요.' />
+            <Input id={FORM_FIELDS.DETAIL_ADDRESS} placeholder={PLACEHOLDER_TEXTS.DETAIL_ADDRESS} />
           </div>
           <div className='flex flex-col gap-2'>
-            <Label className='text-sm font-medium'>보증금</Label>
+            <Label className='text-sm font-medium'>{LABEL_TEXTS.DEPOSIT}</Label>
             <RadioGroup
               value={rentType}
-              onValueChange={(value) => setRentType(value as 'jeonse' | 'monthly')}
+              onValueChange={handleRentTypeChange}
               className='flex items-center gap-4'
             >
-              <div className='flex items-center gap-2'>
-                <RadioGroupItem value='jeonse' id='jeonse' />
-                <Label htmlFor='jeonse' className='text-sm'>
-                  전세
-                </Label>
-              </div>
-              <div className='flex items-center gap-2'>
-                <RadioGroupItem value='monthly' id='monthly' />
-                <Label htmlFor='monthly' className='text-sm'>
-                  월세
-                </Label>
-              </div>
+              {Object.entries(RENT_TYPE_CONFIG).map(([value, config]) => (
+                <div key={value} className='flex items-center gap-2'>
+                  <RadioGroupItem value={value} id={value} />
+                  <Label htmlFor={value} className='text-sm'>
+                    {config.label}
+                  </Label>
+                </div>
+              ))}
             </RadioGroup>
           </div>
           <div className='flex flex-col gap-2'>
             <div className='relative'>
-              <Input
-                placeholder={rentType === 'jeonse' ? '전세금액' : '월세금액'}
-                className='pr-12'
-              />
+              <Input placeholder={currentRentConfig.placeholder} className='pr-12' />
               <span className='absolute top-1/2 right-4 -translate-y-1/2 transform text-sm font-semibold text-gray-600'>
                 원
               </span>

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -1,26 +1,40 @@
+import { useState } from 'react';
+
 import { Button, Input, Label, RadioGroup, RadioGroupItem } from '@/shared';
 
 export const DiagnosticForm = () => {
+  const [rentType, setRentType] = useState<'jeonse' | 'monthly'>('jeonse');
+
   //TODO: 추후 Form 컴포넌트로 리팩토링
   return (
     <div className='mt-10 flex w-full flex-col items-center gap-2'>
       <div className='flex w-4/5 flex-col gap-2'>
         <div className='flex w-full flex-col gap-4'>
           <div className='flex flex-col gap-2'>
-            <label className='text-sm font-medium'>주소</label>
-            <Input placeholder='주소를 알려주세요' />
+            <Label htmlFor='address' className='text-sm font-medium'>
+              주소
+            </Label>
+            <Input id='address' placeholder='주소를 알려주세요' />
           </div>
           <div className='flex flex-col gap-2'>
-            <label className='text-sm font-medium'>주택유형</label>
-            <Input placeholder='주택유형을 알려주세요' />
+            <Label htmlFor='house-type' className='text-sm font-medium'>
+              주택유형
+            </Label>
+            <Input id='house-type' placeholder='주택유형을 알려주세요' />
           </div>
           <div className='flex flex-col gap-2'>
-            <label className='text-sm font-medium'>상세주소</label>
-            <Input placeholder='상세주소를 알려주세요.' />
+            <Label htmlFor='detail-address' className='text-sm font-medium'>
+              상세주소
+            </Label>
+            <Input id='detail-address' placeholder='상세주소를 알려주세요.' />
           </div>
           <div className='flex flex-col gap-2'>
-            <label className='text-sm font-medium'>보증금</label>
-            <RadioGroup defaultValue='jeonse' className='flex items-center gap-4'>
+            <Label className='text-sm font-medium'>보증금</Label>
+            <RadioGroup
+              value={rentType}
+              onValueChange={(value) => setRentType(value as 'jeonse' | 'monthly')}
+              className='flex items-center gap-4'
+            >
               <div className='flex items-center gap-2'>
                 <RadioGroupItem value='jeonse' id='jeonse' />
                 <Label htmlFor='jeonse' className='text-sm'>
@@ -37,8 +51,11 @@ export const DiagnosticForm = () => {
           </div>
           <div className='flex flex-col gap-2'>
             <div className='relative'>
-              <Input placeholder='전세금' className='pr-12' />
-              <span className='absolute top-1/2 right-3 -translate-y-1/2 transform text-sm text-gray-600'>
+              <Input
+                placeholder={rentType === 'jeonse' ? '전세금액' : '월세금액'}
+                className='pr-12'
+              />
+              <span className='absolute top-1/2 right-4 -translate-y-1/2 transform text-sm font-semibold text-gray-600'>
                 원
               </span>
             </div>

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -1,0 +1,53 @@
+import { Button, Input, Label, RadioGroup, RadioGroupItem } from '@/shared';
+
+export const DiagnosticForm = () => {
+  //TODO: 추후 Form 컴포넌트로 리팩토링
+  return (
+    <div className='mt-10 flex w-full flex-col items-center gap-2'>
+      <div className='flex w-4/5 flex-col gap-2'>
+        <div className='flex w-full flex-col gap-4'>
+          <div className='flex flex-col gap-2'>
+            <label className='text-sm font-medium'>주소</label>
+            <Input placeholder='주소를 알려주세요' />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='text-sm font-medium'>주택유형</label>
+            <Input placeholder='주택유형을 알려주세요' />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='text-sm font-medium'>상세주소</label>
+            <Input placeholder='상세주소를 알려주세요.' />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label className='text-sm font-medium'>보증금</label>
+            <RadioGroup defaultValue='jeonse' className='flex items-center gap-4'>
+              <div className='flex items-center gap-2'>
+                <RadioGroupItem value='jeonse' id='jeonse' />
+                <Label htmlFor='jeonse' className='text-sm'>
+                  전세
+                </Label>
+              </div>
+              <div className='flex items-center gap-2'>
+                <RadioGroupItem value='monthly' id='monthly' />
+                <Label htmlFor='monthly' className='text-sm'>
+                  월세
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+          <div className='flex flex-col gap-2'>
+            <div className='relative'>
+              <Input placeholder='전세금' className='pr-12' />
+              <span className='absolute top-1/2 right-3 -translate-y-1/2 transform text-sm text-gray-600'>
+                원
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className='py-10'>
+          <Button className='w-full'>진단하기</Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/main/components/features/form/index.ts
+++ b/src/features/main/components/features/form/index.ts
@@ -1,0 +1,1 @@
+export * from './DiagnosticForm';

--- a/src/features/main/components/features/index.ts
+++ b/src/features/main/components/features/index.ts
@@ -1,0 +1,1 @@
+export * from './form';

--- a/src/features/main/components/index.ts
+++ b/src/features/main/components/index.ts
@@ -1,0 +1,1 @@
+export * from './features';

--- a/src/features/main/constants/form-type.ts
+++ b/src/features/main/constants/form-type.ts
@@ -1,0 +1,44 @@
+// 임대 유형 상수
+export const RENT_TYPES = {
+  JEONSE: 'jeonse',
+  MONTHLY: 'monthly',
+} as const;
+
+// 폼 필드 상수
+export const FORM_FIELDS = {
+  ADDRESS: 'address',
+  HOUSE_TYPE: 'house-type',
+  DETAIL_ADDRESS: 'detail-address',
+  RENT_AMOUNT: 'rent-amount',
+} as const;
+
+// 플레이스홀더 텍스트 상수
+export const PLACEHOLDER_TEXTS = {
+  ADDRESS: '주소를 알려주세요',
+  HOUSE_TYPE: '주택유형을 알려주세요',
+  DETAIL_ADDRESS: '상세주소를 알려주세요.',
+  JEONSE_AMOUNT: '전세금액',
+  MONTHLY_AMOUNT: '월세금액',
+} as const;
+
+// 라벨 텍스트 상수
+export const LABEL_TEXTS = {
+  ADDRESS: '주소',
+  HOUSE_TYPE: '주택유형',
+  DETAIL_ADDRESS: '상세주소',
+  DEPOSIT: '보증금',
+  JEONSE: '전세',
+  MONTHLY: '월세',
+} as const;
+
+// 임대 유형별 설정 객체
+export const RENT_TYPE_CONFIG = {
+  [RENT_TYPES.JEONSE]: {
+    label: LABEL_TEXTS.JEONSE,
+    placeholder: PLACEHOLDER_TEXTS.JEONSE_AMOUNT,
+  },
+  [RENT_TYPES.MONTHLY]: {
+    label: LABEL_TEXTS.MONTHLY,
+    placeholder: PLACEHOLDER_TEXTS.MONTHLY_AMOUNT,
+  },
+} as const;

--- a/src/features/main/constants/house-type.ts
+++ b/src/features/main/constants/house-type.ts
@@ -1,0 +1,2 @@
+// 주택 유형 상수
+export const HOUSE_TYPES = ['원룸', '투룸', '오피스텔', '아파트', '복층'] as const;

--- a/src/features/main/constants/index.ts
+++ b/src/features/main/constants/index.ts
@@ -1,0 +1,2 @@
+export * from './form-type';
+export * from './house-type';

--- a/src/features/main/index.ts
+++ b/src/features/main/index.ts
@@ -1,0 +1,1 @@
+export * from './ui';

--- a/src/features/main/types/house-types.type.ts
+++ b/src/features/main/types/house-types.type.ts
@@ -1,0 +1,5 @@
+import type { FORM_FIELDS, HOUSE_TYPES, RENT_TYPES } from '../constants';
+
+export type RentType = (typeof RENT_TYPES)[keyof typeof RENT_TYPES];
+export type HouseType = (typeof HOUSE_TYPES)[number];
+export type FormField = (typeof FORM_FIELDS)[keyof typeof FORM_FIELDS];

--- a/src/features/main/types/index.ts
+++ b/src/features/main/types/index.ts
@@ -1,0 +1,1 @@
+export * from './house-types.type';

--- a/src/features/main/ui/InputSection.tsx
+++ b/src/features/main/ui/InputSection.tsx
@@ -1,0 +1,18 @@
+import { DiagnosticForm } from '../components';
+
+export const InputSection = () => {
+  return (
+    <div className='flex w-1/2 flex-col items-center justify-center gap-6 p-8'>
+      <div className='flex w-full max-w-md flex-col gap-4'>
+        <div className='flex flex-col gap-1'>
+          <span className='flex text-3xl font-bold'>
+            <p className='text-lighthouse-blue'>계약&nbsp;</p>
+            <p>하려고 하는 그 집</p>
+          </span>
+          <span className='text-4xl font-bold'>안심할 수 있는지 확인해봐요!</span>
+        </div>
+        <DiagnosticForm />
+      </div>
+    </div>
+  );
+};

--- a/src/features/main/ui/MapSection.tsx
+++ b/src/features/main/ui/MapSection.tsx
@@ -1,24 +1,16 @@
 import { Button } from '@/shared';
 
+import { HOUSE_TYPES } from '../constants';
+
 export const MapSection = () => {
   return (
     <div className='flex w-1/2 flex-col border-l border-gray-200'>
       <div className='flex gap-3 border-b border-gray-200 p-4'>
-        <Button variant='secondary' size='sm'>
-          원룸
-        </Button>
-        <Button variant='secondary' size='sm'>
-          투룸
-        </Button>
-        <Button variant='secondary' size='sm'>
-          오피스텔
-        </Button>
-        <Button variant='secondary' size='sm'>
-          아파트
-        </Button>
-        <Button variant='secondary' size='sm'>
-          복층
-        </Button>
+        {HOUSE_TYPES.map((type) => (
+          <Button key={type} variant='secondary' size='sm'>
+            {type}
+          </Button>
+        ))}
       </div>
 
       {/* TODO: 추후 지도 (카카오맵, 네이버 지도, 구글 맵 등) 컴포넌트 추가 */}

--- a/src/features/main/ui/MapSection.tsx
+++ b/src/features/main/ui/MapSection.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@/shared';
+
+export const MapSection = () => {
+  return (
+    <div className='flex w-1/2 flex-col border-l border-gray-200'>
+      <div className='flex gap-3 border-b border-gray-200 p-4'>
+        <Button variant='secondary' size='sm'>
+          원룸
+        </Button>
+        <Button variant='secondary' size='sm'>
+          투룸
+        </Button>
+        <Button variant='secondary' size='sm'>
+          오피스텔
+        </Button>
+        <Button variant='secondary' size='sm'>
+          아파트
+        </Button>
+        <Button variant='secondary' size='sm'>
+          복층
+        </Button>
+      </div>
+
+      {/* TODO: 추후 지도 (카카오맵, 네이버 지도, 구글 맵 등) 컴포넌트 추가 */}
+      <div className='flex flex-1 items-center justify-center bg-gray-100'>
+        <div className='text-center text-gray-500'>
+          <p className='mb-2 text-lg font-medium'>지도가 여기에 표시됩니다</p>
+          <p className='text-sm'>주소를 입력하고 진단하기를 눌러보세요</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/main/ui/index.ts
+++ b/src/features/main/ui/index.ts
@@ -1,0 +1,2 @@
+export * from './InputSection';
+export * from './MapSection';

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,3 +1,10 @@
+import { InputSection, MapSection } from '@/features';
+
 export default function MainPage() {
-  return <div>MainPage</div>;
+  return (
+    <div className='flex h-screen w-full'>
+      <InputSection />
+      <MapSection />
+    </div>
+  );
 }

--- a/src/shared/components/ui/index.ts
+++ b/src/shared/components/ui/index.ts
@@ -5,3 +5,4 @@ export * from './sonner';
 export * from './form';
 export * from './label';
 export * from './avatar';
+export * from './radio-group';

--- a/src/shared/components/ui/input.tsx
+++ b/src/shared/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot='input'
       className={cn(
-        'flex h-9 w-full min-w-0 rounded-full bg-transparent px-3 py-1 text-base shadow-[0px_4px_30px_0px_#0000001A] transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input-placeholder-gray disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
+        'flex h-9 w-full min-w-0 rounded-full bg-transparent px-5 py-1 text-base shadow-[0px_4px_30px_0px_#0000001A] transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input-placeholder-gray disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
         'focus-visible:border-lighthouse-blue focus-visible:shadow-lighthouse-blue-shadow',
         'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
         className,

--- a/src/shared/components/ui/radio-group.tsx
+++ b/src/shared/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { CircleIcon } from 'lucide-react';
+
+import { cn } from '../../utils';
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot='radio-group'
+      className={cn('grid gap-3', className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot='radio-group-item'
+      className={cn(
+        'aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot='radio-group-indicator'
+        className='relative flex items-center justify-center'
+      >
+        <CircleIcon className='absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-[#4353ff]' />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/src/shared/styles/design-tokens/layout-tokens.ts
+++ b/src/shared/styles/design-tokens/layout-tokens.ts
@@ -1,8 +1,8 @@
 export const HEADER_TOKENS = {
-  base: 'fixed top-0 right-0 left-0 z-100 flex h-header items-center border-b border-gray-200 justify-between px-header transition-colors',
+  base: 'fixed top-0 right-0 bg-white left-0 z-100 flex h-header items-center border-b border-gray-200 justify-between px-header transition-colors',
   variants: {
-    auth: 'bg-amber-100',
-    main: 'bg-blog-gray-500',
+    auth: '',
+    main: '',
     realtor: '', // 기본 배경색 사용
   },
 } as const;


### PR DESCRIPTION
## 📝 요약 (Summary)
이번 PR은 메인 페이지의 사용자 인터페이스를 구축하고, 진단 폼에 필요한 InputSection, MapSection, RadioGroup 등 핵심 컴포넌트를 추가 및 구성합니다. 이를 통해 애플리케이션의 초기 UI 레이아웃과 주요 기능 컴포넌트가 마련됩니다.

## ✅ 주요 변경 사항 (Key Changes)

-   메인 페이지에 필요한 주요 섹션 컴포넌트 (InputSection, MapSection) 추가
-   재사용 가능한 UI 컴포넌트 (RadioGroup, RadioGroupItem) 개발 및 통합
-   초기 컴포넌트 폴더 구조 설정 및 외부 UI 라이브러리 의존성 추가

## 💻 상세 구현 내용 (Implementation Details)

*   **메인 페이지 섹션 컴포넌트 추가:**
    *   `MainPage`에 사용자 입력을 처리하는 `InputSection`과 지도 정보를 표시하는 `MapSection` 컴포넌트가 추가되었습니다. 이는 메인 페이지의 전체적인 레이아웃을 구성하며, 각 섹션은 독립적인 기능을 담당합니다.
    *   `InputSection`은 진단 폼의 입력 필드를 포함하며, 관련 파일들을 체계적으로 정리하여 모듈성을 높였습니다.
    *   `MapSection`은 지도 관련 UI를 담당하며, 내부적으로 필요한 버튼 요소들이 구성되었습니다.
*   **재사용 가능한 UI 컴포넌트 개발 및 통합:**
    *   사용자가 여러 옵션 중 하나를 선택할 수 있도록 하는 `RadioGroup` 및 `RadioGroupItem` 컴포넌트가 새로 추가되었습니다. 이 컴포넌트들은 `@radix-ui/react-radio-group` 라이브러리를 활용하여 접근성과 재사용성을 고려하여 구현되었습니다.
    *   새로 개발된 `RadioGroup` 컴포넌트는 전역 `index` 파일에 노출되어 다른 컴포넌트에서 쉽게 import하여 사용할 수 있도록 접근성을 확보했습니다.
    *   `Input` 컴포넌트의 패딩을 수정하여 전반적인 UI의 일관성을 개선하고 시각적 통일감을 주었습니다.
    *   `Header` 컴포넌트의 스타일 및 배경색을 변경하여 애플리케이션의 브랜드 아이덴티티를 강화하고 시각적으로 더 매력적인 UI를 제공합니다.
*   **초기 컴포넌트 폴더 구조 설정 및 의존성 추가:**
    *   `src/components` 내부에 `common`, `domain`, `layout` 등 역할에 따른 폴더 구조를 생성하여 컴포넌트들을 논리적으로 분리하고, 향후 기능 확장을 용이하게 했습니다.
    *   진단 폼의 기반이 될 수 있는 "진단 폼 컴포넌트"가 추가되었으며, 이와 관련된 파일 구조도 함께 정리되었습니다.
    *   `@radix-ui/react-radio-group` 패키지를 프로젝트에 추가하고 `pnpm-lock.yaml` 파일을 업데이트하여, `RadioGroup` 컴포넌트 구현에 필요한 외부 의존성을 성공적으로 통합했습니다.

## 🚀 트러블 슈팅 (Trouble Shooting)
본 PR에서는 특정 버그 수정이 포함되어 있지 않습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)
현재 알려진 이슈는 없습니다.

## 📸 스크린샷 (Screenshots)
<img width="776" height="494" alt="스크린샷 2025-08-19 오후 1 31 11" src="https://github.com/user-attachments/assets/bbb2fb6b-d6bf-4e7b-881e-9b1a28481e07" />


## #️⃣ 관련 이슈 (Related Issues)
-