### PR TITLE
feat: 주소 검색 및 진단 폼 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.10)(react@19.1.1)
@@ -409,6 +412,21 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@hookform/resolvers@5.2.1':
     resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
     peerDependencies:
@@ -473,8 +491,24 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-avatar@1.1.10':
     resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
@@ -542,6 +576,41 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -553,6 +622,32 @@ packages:
 
   '@radix-ui/react-label@2.1.7':
     resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -616,6 +711,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -652,6 +760,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-is-hydrated@0.1.0':
     resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
@@ -679,6 +796,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -687,6 +813,22 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
@@ -1254,6 +1396,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1500,6 +1646,9 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1806,6 +1955,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2467,6 +2620,26 @@ packages:
       redux:
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.1:
+    resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.8.1:
     resolution: {integrity: sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==}
     engines: {node: '>=20.0.0'}
@@ -2482,6 +2655,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.1.1:
@@ -2788,6 +2971,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sync-external-store@1.5.0:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
@@ -3070,6 +3273,23 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -3132,7 +3352,18 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -3193,6 +3424,36 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.10)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
@@ -3203,6 +3464,34 @@ snapshots:
   '@radix-ui/react-label@2.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
@@ -3263,6 +3552,35 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.10)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
@@ -3291,6 +3609,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.10)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
   '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       react: 19.1.1
@@ -3310,12 +3635,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.10)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.1.10)(react@19.1.1)(redux@5.0.1))(react@19.1.1)':
     dependencies:
@@ -3783,6 +4126,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -4043,6 +4390,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-libc@2.0.4: {}
+
+  detect-node-es@1.1.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -4496,6 +4845,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -5053,6 +5404,25 @@ snapshots:
       '@types/react': 19.1.10
       redux: 5.0.1
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-style-singleton: 2.2.3(@types/react@19.1.10)(react@19.1.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  react-remove-scroll@2.7.1(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.10)(react@19.1.1)
+      react-style-singleton: 2.2.3(@types/react@19.1.10)(react@19.1.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.10)(react@19.1.1)
+      use-sidecar: 1.1.3(@types/react@19.1.10)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+
   react-router-dom@7.8.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -5066,6 +5436,14 @@ snapshots:
       set-cookie-parser: 2.7.1
     optionalDependencies:
       react-dom: 19.1.1(react@19.1.1)
+
+  react-style-singleton@2.2.3(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.10
 
   react@19.1.1: {}
 
@@ -5398,8 +5776,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tw-animate-css@1.3.7: {}
 
@@ -5489,6 +5866,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  use-sidecar@1.1.3(@types/react@19.1.10)(react@19.1.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.10
 
   use-sync-external-store@1.5.0(react@19.1.1):
     dependencies:

--- a/src/features/main/apis/diagnosis.api.ts
+++ b/src/features/main/apis/diagnosis.api.ts
@@ -1,0 +1,28 @@
+import { fetchInstance } from '@/shared';
+
+import type { HouseType } from '../types';
+
+export const DIAGNOSIS_API_PATH = '/api/diagnosis';
+
+interface DiagnosisApiResponse {
+  address: string;
+  addressDetail: string;
+  houseType: HouseType;
+  deposit: number;
+}
+
+export const diagnosisApi = async ({
+  address,
+  addressDetail,
+  houseType,
+  deposit,
+}: DiagnosisApiResponse) => {
+  const response = await fetchInstance.post<DiagnosisApiResponse>(DIAGNOSIS_API_PATH, {
+    address,
+    addressDetail,
+    houseType,
+    deposit,
+  });
+
+  return response.data;
+};

--- a/src/features/main/apis/index.ts
+++ b/src/features/main/apis/index.ts
@@ -1,0 +1,1 @@
+export * from './diagnosis.api';

--- a/src/features/main/components/common/AddressField.tsx
+++ b/src/features/main/components/common/AddressField.tsx
@@ -1,0 +1,23 @@
+import { useFormContext } from 'react-hook-form';
+
+import { FormField, FormItem, FormLabel, FormMessage, Input } from '@/shared';
+
+import { FORM_FIELDS, LABEL_TEXTS, PLACEHOLDER_TEXTS } from '../../constants';
+import { type SearchAddressType } from '../../model';
+
+export const AddressField = () => {
+  const form = useFormContext<SearchAddressType>();
+  return (
+    <FormField
+      control={form.control}
+      name='address'
+      render={({ field }) => (
+        <FormItem className='flex flex-col gap-2'>
+          <FormLabel htmlFor={FORM_FIELDS.ADDRESS}>{LABEL_TEXTS.ADDRESS}</FormLabel>
+          <Input {...field} placeholder={PLACEHOLDER_TEXTS.ADDRESS} />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/features/main/components/common/DepositField.tsx
+++ b/src/features/main/components/common/DepositField.tsx
@@ -1,0 +1,43 @@
+import { useFormContext } from 'react-hook-form';
+
+import { FormField, FormItem, FormMessage, Input } from '@/shared';
+
+import { PLACEHOLDER_TEXTS } from '../../constants';
+import type { SearchAddressType } from '../../model';
+
+export const DepositField = () => {
+  const form = useFormContext<SearchAddressType>();
+
+  const convertToNumber = (value: string, onChange: (value: number) => void) => {
+    const numValue = value === '' ? 0 : Number(value);
+    const safeValue = isNaN(numValue) ? 0 : numValue;
+    onChange(safeValue);
+  };
+
+  const getDisplayValue = (value: number) => {
+    return value === 0 ? '' : String(value);
+  };
+
+  return (
+    <FormField
+      control={form.control}
+      name='deposit'
+      render={({ field }) => (
+        <FormItem className='flex flex-col gap-2'>
+          <div className='relative'>
+            <Input
+              {...field}
+              placeholder={PLACEHOLDER_TEXTS.DEPOSIT}
+              onChange={(e) => convertToNumber(e.target.value, field.onChange)}
+              value={getDisplayValue(field.value)}
+            />
+            <span className='absolute top-1/2 right-4 -translate-y-1/2 transform text-sm font-semibold text-[#333D4B]'>
+              원
+            </span>
+          </div>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/features/main/components/common/DetailAddressField.tsx
+++ b/src/features/main/components/common/DetailAddressField.tsx
@@ -1,0 +1,23 @@
+import { useFormContext } from 'react-hook-form';
+
+import { FormField, FormItem, FormLabel, FormMessage, Input } from '@/shared';
+
+import { FORM_FIELDS, LABEL_TEXTS, PLACEHOLDER_TEXTS } from '../../constants';
+import type { SearchAddressType } from '../../model';
+
+export const DetailAddressField = () => {
+  const form = useFormContext<SearchAddressType>();
+  return (
+    <FormField
+      control={form.control}
+      name='detailAddress'
+      render={({ field }) => (
+        <FormItem className='flex flex-col gap-2'>
+          <FormLabel htmlFor={FORM_FIELDS.DETAIL_ADDRESS}>{LABEL_TEXTS.DETAIL_ADDRESS}</FormLabel>
+          <Input {...field} placeholder={PLACEHOLDER_TEXTS.DETAIL_ADDRESS} />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/features/main/components/common/HouseTypeField.tsx
+++ b/src/features/main/components/common/HouseTypeField.tsx
@@ -1,20 +1,50 @@
 import { useFormContext } from 'react-hook-form';
 
-import { FormField, FormItem, FormLabel, FormMessage, Input } from '@/shared';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared';
 
-import { FORM_FIELDS, LABEL_TEXTS, PLACEHOLDER_TEXTS } from '../../constants';
+import { HOUSE_TYPE_OPTIONS, LABEL_TEXTS } from '../../constants';
 import type { SearchAddressType } from '../../model';
 
 export const HouseTypeField = () => {
   const form = useFormContext<SearchAddressType>();
+
   return (
     <FormField
       control={form.control}
       name='houseType'
       render={({ field }) => (
         <FormItem className='flex flex-col gap-2'>
-          <FormLabel htmlFor={FORM_FIELDS.HOUSE_TYPE}>{LABEL_TEXTS.HOUSE_TYPE}</FormLabel>
-          <Input {...field} placeholder={PLACEHOLDER_TEXTS.HOUSE_TYPE} />
+          <FormLabel>{LABEL_TEXTS.HOUSE_TYPE}</FormLabel>
+          <Select onValueChange={field.onChange} defaultValue={field.value}>
+            <FormControl>
+              <SelectTrigger className='w-full rounded-full border-none shadow-[0px_4px_30px_0px_#0000001A] focus-visible:border-lighthouse-blue focus-visible:shadow-lighthouse-blue-shadow [&_span]:text-input-placeholder-gray'>
+                <SelectValue placeholder='주택유형을 선택해주세요' />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>{LABEL_TEXTS.HOUSE_TYPE}</SelectLabel>
+                {HOUSE_TYPE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
           <FormMessage />
         </FormItem>
       )}

--- a/src/features/main/components/common/HouseTypeField.tsx
+++ b/src/features/main/components/common/HouseTypeField.tsx
@@ -1,0 +1,23 @@
+import { useFormContext } from 'react-hook-form';
+
+import { FormField, FormItem, FormLabel, FormMessage, Input } from '@/shared';
+
+import { FORM_FIELDS, LABEL_TEXTS, PLACEHOLDER_TEXTS } from '../../constants';
+import type { SearchAddressType } from '../../model';
+
+export const HouseTypeField = () => {
+  const form = useFormContext<SearchAddressType>();
+  return (
+    <FormField
+      control={form.control}
+      name='houseType'
+      render={({ field }) => (
+        <FormItem className='flex flex-col gap-2'>
+          <FormLabel htmlFor={FORM_FIELDS.HOUSE_TYPE}>{LABEL_TEXTS.HOUSE_TYPE}</FormLabel>
+          <Input {...field} placeholder={PLACEHOLDER_TEXTS.HOUSE_TYPE} />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/features/main/components/common/RentTypeField.tsx
+++ b/src/features/main/components/common/RentTypeField.tsx
@@ -1,0 +1,22 @@
+import { Label, RadioGroup, RadioGroupItem } from '@/shared';
+
+export const RentTypeField = () => {
+  return (
+    <div className='flex flex-col gap-2'>
+      <Label className='text-sm font-medium'>임대 유형</Label>
+      <RadioGroup value='jeonse' className='flex items-center gap-4'>
+        <div className='flex items-center gap-2'>
+          <RadioGroupItem
+            value='jeonse'
+            id='jeonse'
+            checked
+            className='data-[state=checked]:border-[#8A8A8A] data-[state=checked]:before:bg-[#4353FF]'
+          />
+          <Label htmlFor='jeonse' className='text-sm'>
+            전세
+          </Label>
+        </div>
+      </RadioGroup>
+    </div>
+  );
+};

--- a/src/features/main/components/common/index.ts
+++ b/src/features/main/components/common/index.ts
@@ -4,3 +4,8 @@ export * from './ChartLineItem';
 export * from './LegendLine';
 export * from './Needle';
 export * from './Pagination';
+export * from './AddressField';
+export * from './HouseTypeField';
+export * from './DetailAddressField';
+export * from './DepositField';
+export * from './RentTypeField';

--- a/src/features/main/components/features/chart/RiskChartBox.tsx
+++ b/src/features/main/components/features/chart/RiskChartBox.tsx
@@ -24,7 +24,7 @@ export const RiskChartBox = ({ riskScore, title }: Props) => {
   const needleAngle = getGaugeAngle(riskScore);
 
   return (
-    <div className='w-full rounded-lg bg-white p-6'>
+    <div className='w-full rounded-lg bg-white pt-6'>
       <h3 className='mb-2 text-2xl font-bold text-gray-900'>{title}</h3>
       <p className='text-md mb-6 flex items-center gap-2 text-gray-600'>
         <span className='font-semibold'>위험 점수 :</span>

--- a/src/features/main/components/features/chart/RiskFactorsBox.tsx
+++ b/src/features/main/components/features/chart/RiskFactorsBox.tsx
@@ -13,9 +13,9 @@ export const RiskFactorsBox = ({ riskFactors }: Props) => {
           <div key={factor.name} className='flex items-center gap-5 py-3 text-center font-semibold'>
             <div className='size-1 rounded-full bg-black' />
             <span className='flex items-center gap-2 text-gray-900'>
-              <span className='text-lg text-lighthouse-blue'>{factor.name}</span>
-              <div className='flex items-center gap-1'>
-                <span className='font-medium text-red-500'>{factor.percent}</span>
+              <span className='text-lg text-black'>{factor.name}</span>
+              <div className='flex items-center gap-1 font-semibold'>
+                <span className='text-red-500'>{factor.percent}</span>
                 <span className='text-black'>%</span>
               </div>
             </span>

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -41,7 +41,6 @@ export const DiagnosticForm = () => {
     diagnosisMutate(data);
   };
 
-  //TODO: 추후 Form 컴포넌트로 리팩토링
   return (
     <Form {...form}>
       <form

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -1,10 +1,13 @@
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
 
 import { Button, Form } from '@/shared';
 
+import { diagnosisApi } from '../../../apis';
 import { type SearchAddressType, searchAddressSchema } from '../../../model';
+import type { HouseType } from '../../../types';
 import {
   AddressField,
   DepositField,
@@ -24,8 +27,18 @@ export const DiagnosticForm = () => {
     },
   });
 
+  const { mutate: diagnosisMutate } = useMutation({
+    mutationFn: (data: SearchAddressType) =>
+      diagnosisApi({
+        address: data.address,
+        addressDetail: data.detailAddress,
+        houseType: data.houseType as HouseType,
+        deposit: data.deposit,
+      }),
+  });
+
   const onSubmit = (data: SearchAddressType) => {
-    console.log(data);
+    diagnosisMutate(data);
   };
 
   //TODO: 추후 Form 컴포넌트로 리팩토링

--- a/src/features/main/components/features/form/DiagnosticForm.tsx
+++ b/src/features/main/components/features/form/DiagnosticForm.tsx
@@ -1,78 +1,55 @@
-import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 
-import { Button, Input, Label, RadioGroup, RadioGroupItem } from '@/shared';
+import { zodResolver } from '@hookform/resolvers/zod';
 
+import { Button, Form } from '@/shared';
+
+import { type SearchAddressType, searchAddressSchema } from '../../../model';
 import {
-  FORM_FIELDS,
-  LABEL_TEXTS,
-  PLACEHOLDER_TEXTS,
-  RENT_TYPES,
-  RENT_TYPE_CONFIG,
-} from '../../../constants';
-import type { RentType } from '../../../types';
+  AddressField,
+  DepositField,
+  DetailAddressField,
+  HouseTypeField,
+  RentTypeField,
+} from '../../common';
 
 export const DiagnosticForm = () => {
-  const [rentType, setRentType] = useState<RentType>(RENT_TYPES.JEONSE);
+  const form = useForm<SearchAddressType>({
+    resolver: zodResolver(searchAddressSchema),
+    defaultValues: {
+      address: '',
+      houseType: '',
+      detailAddress: '',
+      deposit: 0,
+    },
+  });
 
-  const handleRentTypeChange = (value: string) => {
-    setRentType(value as RentType);
+  const onSubmit = (data: SearchAddressType) => {
+    console.log(data);
   };
-
-  const currentRentConfig = RENT_TYPE_CONFIG[rentType];
 
   //TODO: 추후 Form 컴포넌트로 리팩토링
   return (
-    <div className='mt-10 flex w-full flex-col items-center gap-2'>
-      <div className='flex w-4/5 flex-col gap-2'>
-        <div className='flex w-full flex-col gap-4'>
-          <div className='flex flex-col gap-2'>
-            <Label htmlFor={FORM_FIELDS.ADDRESS} className='text-sm font-medium'>
-              {LABEL_TEXTS.ADDRESS}
-            </Label>
-            <Input id={FORM_FIELDS.ADDRESS} placeholder={PLACEHOLDER_TEXTS.ADDRESS} />
+    <Form {...form}>
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className='mt-10 flex w-full flex-col items-center gap-2'
+      >
+        <div className='flex w-4/5 flex-col gap-2'>
+          <div className='flex w-full flex-col gap-5'>
+            <AddressField />
+            <HouseTypeField />
+            <DetailAddressField />
+            <RentTypeField />
+            <DepositField />
           </div>
-          <div className='flex flex-col gap-2'>
-            <Label htmlFor={FORM_FIELDS.HOUSE_TYPE} className='text-sm font-medium'>
-              {LABEL_TEXTS.HOUSE_TYPE}
-            </Label>
-            <Input id={FORM_FIELDS.HOUSE_TYPE} placeholder={PLACEHOLDER_TEXTS.HOUSE_TYPE} />
-          </div>
-          <div className='flex flex-col gap-2'>
-            <Label htmlFor={FORM_FIELDS.DETAIL_ADDRESS} className='text-sm font-medium'>
-              {LABEL_TEXTS.DETAIL_ADDRESS}
-            </Label>
-            <Input id={FORM_FIELDS.DETAIL_ADDRESS} placeholder={PLACEHOLDER_TEXTS.DETAIL_ADDRESS} />
-          </div>
-          <div className='flex flex-col gap-2'>
-            <Label className='text-sm font-medium'>{LABEL_TEXTS.DEPOSIT}</Label>
-            <RadioGroup
-              value={rentType}
-              onValueChange={handleRentTypeChange}
-              className='flex items-center gap-4'
-            >
-              {Object.entries(RENT_TYPE_CONFIG).map(([value, config]) => (
-                <div key={value} className='flex items-center gap-2'>
-                  <RadioGroupItem value={value} id={value} />
-                  <Label htmlFor={value} className='text-sm'>
-                    {config.label}
-                  </Label>
-                </div>
-              ))}
-            </RadioGroup>
-          </div>
-          <div className='flex flex-col gap-2'>
-            <div className='relative'>
-              <Input placeholder={currentRentConfig.placeholder} className='pr-12' />
-              <span className='absolute top-1/2 right-4 -translate-y-1/2 transform text-sm font-semibold text-gray-600'>
-                원
-              </span>
-            </div>
+          <div className='py-10'>
+            <Button className='w-full' onClick={form.handleSubmit(onSubmit)}>
+              진단하기
+            </Button>
           </div>
         </div>
-        <div className='py-10'>
-          <Button className='w-full'>진단하기</Button>
-        </div>
-      </div>
-    </div>
+      </form>
+    </Form>
   );
 };

--- a/src/features/main/components/features/reliability/ReasonBox.tsx
+++ b/src/features/main/components/features/reliability/ReasonBox.tsx
@@ -11,7 +11,7 @@ export const ReasonBox = () => {
         >
           <div className='size-1 rounded-full bg-black' />
           <span className='flex items-center gap-2 text-gray-900'>
-            <span className='text-lg text-lighthouse-blue'>{reason.name}</span>
+            <span className='text-lg text-black'>{reason.name}</span>
             <div className='flex items-center gap-1'>
               <span className='font-medium text-red-500'>{reason.percent}</span>
               <span className='text-black'>%</span>

--- a/src/features/main/constants/form-type.ts
+++ b/src/features/main/constants/form-type.ts
@@ -1,15 +1,8 @@
-// 임대 유형 상수
-export const RENT_TYPES = {
-  JEONSE: 'jeonse',
-  MONTHLY: 'monthly',
-} as const;
-
 // 폼 필드 상수
 export const FORM_FIELDS = {
   ADDRESS: 'address',
   HOUSE_TYPE: 'house-type',
   DETAIL_ADDRESS: 'detail-address',
-  RENT_AMOUNT: 'rent-amount',
 } as const;
 
 // 플레이스홀더 텍스트 상수
@@ -17,8 +10,7 @@ export const PLACEHOLDER_TEXTS = {
   ADDRESS: '주소를 알려주세요',
   HOUSE_TYPE: '주택유형을 알려주세요',
   DETAIL_ADDRESS: '상세주소를 알려주세요.',
-  JEONSE_AMOUNT: '전세금액',
-  MONTHLY_AMOUNT: '월세금액',
+  DEPOSIT: '전세금액',
 } as const;
 
 // 라벨 텍스트 상수
@@ -27,18 +19,4 @@ export const LABEL_TEXTS = {
   HOUSE_TYPE: '주택유형',
   DETAIL_ADDRESS: '상세주소',
   DEPOSIT: '보증금',
-  JEONSE: '전세',
-  MONTHLY: '월세',
-} as const;
-
-// 임대 유형별 설정 객체
-export const RENT_TYPE_CONFIG = {
-  [RENT_TYPES.JEONSE]: {
-    label: LABEL_TEXTS.JEONSE,
-    placeholder: PLACEHOLDER_TEXTS.JEONSE_AMOUNT,
-  },
-  [RENT_TYPES.MONTHLY]: {
-    label: LABEL_TEXTS.MONTHLY,
-    placeholder: PLACEHOLDER_TEXTS.MONTHLY_AMOUNT,
-  },
 } as const;

--- a/src/features/main/constants/house-type.ts
+++ b/src/features/main/constants/house-type.ts
@@ -1,2 +1,10 @@
 // 주택 유형 상수
 export const HOUSE_TYPES = ['원룸', '투룸', '오피스텔', '아파트', '복층'] as const;
+
+export const HOUSE_TYPE_OPTIONS = [
+  { value: 'ONEROOM', label: '원룸' },
+  { value: 'TWOROOM', label: '투룸' },
+  { value: 'OFFICETEL', label: '오피스텔' },
+  { value: 'APARTMENT', label: '아파트' },
+  { value: 'DUPLEX', label: '복층' },
+] as const;

--- a/src/features/main/constants/house-type.ts
+++ b/src/features/main/constants/house-type.ts
@@ -1,10 +1,10 @@
 // 주택 유형 상수
-export const HOUSE_TYPES = ['원룸', '투룸', '오피스텔', '아파트', '복층'] as const;
+export const HOUSE_TYPES = ['원룸', '투룸', '오피스텔', '아파트', '기타'] as const;
 
 export const HOUSE_TYPE_OPTIONS = [
-  { value: 'ONEROOM', label: '원룸' },
-  { value: 'TWOROOM', label: '투룸' },
+  { value: 'ONE_ROOM', label: '원룸' },
+  { value: 'TWO_ROOM', label: '투룸' },
   { value: 'OFFICETEL', label: '오피스텔' },
   { value: 'APARTMENT', label: '아파트' },
-  { value: 'DUPLEX', label: '복층' },
+  { value: 'ETC', label: '기타' },
 ] as const;

--- a/src/features/main/model/index.ts
+++ b/src/features/main/model/index.ts
@@ -1,1 +1,2 @@
 export * from './data';
+export * from './schema';

--- a/src/features/main/model/schema/index.ts
+++ b/src/features/main/model/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './search-address.schema';

--- a/src/features/main/model/schema/search-address.schema.ts
+++ b/src/features/main/model/schema/search-address.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const searchAddressSchema = z.object({
+  address: z.string().min(1, { message: '주소를 입력해주세요.' }),
+  houseType: z.string().min(1, { message: '주거형태를 선택해주세요.' }),
+  detailAddress: z.string().min(1, { message: '상세주소를 입력해주세요.' }),
+  deposit: z.number().min(1, { message: '보증금을 입력해주세요.' }),
+});
+
+export type SearchAddressType = z.infer<typeof searchAddressSchema>;

--- a/src/features/main/types/house-types.type.ts
+++ b/src/features/main/types/house-types.type.ts
@@ -1,4 +1,5 @@
-import type { FORM_FIELDS, HOUSE_TYPES } from '../constants';
+import type { FORM_FIELDS, HOUSE_TYPE_OPTIONS } from '../constants';
 
-export type HouseType = (typeof HOUSE_TYPES)[number];
+export type HouseType = (typeof HOUSE_TYPE_OPTIONS)[number]['value'];
+
 export type FormField = (typeof FORM_FIELDS)[keyof typeof FORM_FIELDS];

--- a/src/features/main/types/house-types.type.ts
+++ b/src/features/main/types/house-types.type.ts
@@ -1,5 +1,4 @@
-import type { FORM_FIELDS, HOUSE_TYPES, RENT_TYPES } from '../constants';
+import type { FORM_FIELDS, HOUSE_TYPES } from '../constants';
 
-export type RentType = (typeof RENT_TYPES)[keyof typeof RENT_TYPES];
 export type HouseType = (typeof HOUSE_TYPES)[number];
 export type FormField = (typeof FORM_FIELDS)[keyof typeof FORM_FIELDS];

--- a/src/features/main/ui/AlternativeSection.tsx
+++ b/src/features/main/ui/AlternativeSection.tsx
@@ -9,7 +9,7 @@ export const AlternativeSection = () => {
   const riskScore = 70;
 
   return (
-    <div className='mx-auto my-10 w-full max-w-7xl rounded-lg bg-white px-15 py-10 shadow-[0px_4px_30px_0px_#0000001A]'>
+    <div className='mx-auto my-10 w-full max-w-7xl rounded-lg bg-white px-15 pt-10 shadow-[0px_4px_30px_0px_#0000001A]'>
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-2'>
         {/* 왼쪽: 임대인 소유 매물 조회 */}
         <PropertyListBox properties={PROPERTIES_WITH_COLORS} title='대체 매물 추천' />

--- a/src/features/main/ui/LandlordPropertySection.tsx
+++ b/src/features/main/ui/LandlordPropertySection.tsx
@@ -6,7 +6,7 @@ export const LandlordPropertySection = () => {
   const riskScore = 70;
 
   return (
-    <div className='mx-auto my-10 w-full max-w-7xl rounded-lg bg-white px-15 py-10 shadow-[0px_4px_30px_0px_#0000001A]'>
+    <div className='mx-auto my-10 w-full max-w-7xl rounded-lg bg-white px-15 pt-10 shadow-[0px_4px_30px_0px_#0000001A]'>
       <div className='grid grid-cols-1 gap-8 lg:grid-cols-2'>
         {/* 왼쪽: 임대인 소유 매물 조회 */}
         <PropertyListBox properties={SERVER_PROPERTIES} title='임대인 소유 매물 조회' />

--- a/src/features/main/ui/LandlordReliabilitySection.tsx
+++ b/src/features/main/ui/LandlordReliabilitySection.tsx
@@ -2,7 +2,7 @@ import { GradeBox, MultiHouseBox, ReasonBox, SubrogationPaymentBox } from '../co
 
 export const LandlordReliabilitySection = () => {
   return (
-    <div className='mx-auto my-10 w-full max-w-7xl rounded-lg bg-white px-15 py-10 shadow-[0px_4px_30px_0px_#0000001A]'>
+    <div className='mx-auto mt-10 w-full max-w-7xl rounded-lg bg-white px-15 pt-10 shadow-[0px_4px_30px_0px_#0000001A]'>
       <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
         <GradeBox />
         <ReasonBox />

--- a/src/features/main/ui/RiskAnalysisSummarySection.tsx
+++ b/src/features/main/ui/RiskAnalysisSummarySection.tsx
@@ -6,9 +6,9 @@ export const RiskAnalysisSummarySection = () => {
   const currentData = DEFAULT_RISK_ANALYSIS_DATA; // 사진과 일치하는 기본 데이터
 
   return (
-    <div className='mx-auto my-10 flex w-full max-w-7xl rounded-lg bg-white shadow-[0px_4px_30px_0px_#0000001A]'>
+    <div className='mx-auto mt-10 flex w-full max-w-7xl rounded-lg bg-white shadow-[0px_4px_30px_0px_#0000001A]'>
       {/* 메인 위험도 분석 섹션 */}
-      <div className='flex w-full justify-between p-5'>
+      <div className='flex w-full justify-between px-10 pt-5'>
         {/* 왼쪽: 위험도 게이지 */}
         <RiskChartBox
           riskScore={currentData.data.riskSummary.score}

--- a/src/shared/components/ui/index.ts
+++ b/src/shared/components/ui/index.ts
@@ -6,3 +6,4 @@ export * from './form';
 export * from './label';
 export * from './avatar';
 export * from './radio-group';
+export * from './select';

--- a/src/shared/components/ui/select.tsx
+++ b/src/shared/components/ui/select.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+import { cn } from '../../utils';
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot='select' {...props} />;
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot='select-group' {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot='select-value' {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot='select-trigger'
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className='size-4 opacity-50' />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot='select-content'
+        className={cn(
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot='select-label'
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot='select-item'
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className='absolute right-2 flex size-3.5 items-center justify-center'>
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className='size-4' />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot='select-separator'
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot='select-scroll-up-button'
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUpIcon className='size-4' />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot='select-scroll-down-button'
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDownIcon className='size-4' />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/shared/components/ui/select.tsx
+++ b/src/shared/components/ui/select.tsx
@@ -30,7 +30,13 @@ function SelectTrigger({
       data-slot='select-trigger'
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        'flex h-9 w-full min-w-0 rounded-full bg-transparent py-1 pr-3 pl-5 text-base shadow-[0px_4px_30px_0px_#0000001A] transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-input-placeholder-gray disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
+        'focus-visible:border-lighthouse-blue focus-visible:shadow-lighthouse-blue-shadow',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        'flex items-center justify-between gap-2',
+        'data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8',
+        '*:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4 [&_svg:not([class*="text-"])]:text-muted-foreground',
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📋 변경사항 요약

이번 PR에서는 주소 검색 기능과 진단 폼 기능을 구현하고, 관련 UI 컴포넌트들을 개선했습니다.

## 🚀 주요 기능

### 1. 주소 검색 기능 구현
- 주소 관련 필드 컴포넌트 추가 (주소, 상세주소, 보증금, 임대 유형)
- 주택 유형 선택 기능 구현
- 진단 API 연동 및 요청 처리 로직 추가

### 2. 진단 폼 기능 구현
- 진단 폼 컴포넌트 구현
- API 요청을 위한 뮤테이션 추가
- 폼 제출 로직 구현

### 3. UI/UX 개선
- Select 컴포넌트 스타일을 Input과 일관성 있게 개선
- 주택 유형 옵션의 value를 영어로 변경 (ONEROOM, TWOROOM, OFFICETEL, APARTMENT, DUPLEX)
- HouseType 타입을 HOUSE_TYPE_OPTIONS의 value 기반으로 수정
- AlternativeSection, LandlordPropertySection, LandlordReliabilitySection의 패딩 수정

## 📁 변경된 파일들

### 새로운 컴포넌트
-  - 주소 입력 필드
-  - 상세주소 입력 필드
-  - 보증금 입력 필드
-  - 임대 유형 선택 필드
-  - 주택 유형 선택 필드
-  - 진단 폼 컴포넌트

### API 및 타입
-  - 진단 API 구현
-  - 주소 검색 스키마
-  - 주택 유형 타입 정의

### 상수 및 설정
-  - 주택 유형 상수 정의
-  - 폼 타입 상수

### UI 컴포넌트 개선
-  - Select 컴포넌트 스타일 개선
- 여러 Section 컴포넌트들의 패딩 수정

## �� 테스트 체크리스트

- [ ] 주소 검색 기능 정상 동작 확인
- [ ] 진단 폼 제출 기능 확인
- [ ] Select 컴포넌트 스타일 확인
- [ ] 주택 유형 선택 기능 확인
- [ ] 폼 유효성 검사 확인

## 🔧 기술적 개선사항

- TypeScript 타입 안정성 향상
- 컴포넌트 스타일 일관성 개선
- 상수 관리 개선
- API 요청 처리 로직 구현

## 📝 커밋 히스토리

- e0e8011: style: AlternativeSection, LandlordPropertySection, LandlordReliabilitySection의 패딩 수정
- db8ee24: feat: 진단 폼 기능 구현
- 5029270: feat: 주택 유형 상수에서 '복층'을 '기타'로 변경 및 HOUSE_TYPE_OPTIONS의 값 수정
- 763da62: feat: 주택 유형 상수에서 HOUSE_TYPES를 HOUSE_TYPE_OPTIONS로 변경 및 HouseType 타입 수정
- 89304cc: feat: 진단 폼에서 API 요청을 위한 뮤테이션 추가 및 제출 로직 수정
- f476d68: feat: 진단 API 구현 및 요청 처리 로직 추가
- 0635573: feat: 주택 유형 필드에 Select 컴포넌트 적용 및 옵션 표시 기능 추가
- 8980aca: feat: 주택 유형 상수에 선택 옵션 추가
- 96ea367: feat: Select 컴포넌트에 선택 기능 추가 및 스타일 수정
- d6c1f7c: feat: 주소 관련 필드 컴포넌트 추가